### PR TITLE
fix: Allow optional title

### DIFF
--- a/src/react/components/screen/screen-body.tsx
+++ b/src/react/components/screen/screen-body.tsx
@@ -4,7 +4,7 @@ import { Stack, BoxProps } from '@blockstack/ui';
 import { Title, Body, Pretitle } from '../typography';
 
 export interface ScreenBodyProps extends BoxProps {
-  title: string;
+  title?: string;
   pretitle?: string | React.ElementType;
   body?: (string | JSX.Element)[];
   fullWidth?: boolean;
@@ -13,7 +13,7 @@ export interface ScreenBodyProps extends BoxProps {
 export const ScreenBody = ({ title, body, pretitle, fullWidth, ...rest }: ScreenBodyProps) => (
   <Stack spacing={2} mx={fullWidth ? 0 : 6} {...rest}>
     {pretitle && <Pretitle>{pretitle}</Pretitle>}
-    <Title>{title}</Title>
+    {title && <Title>{title}</Title>}
     {body && (
       <Stack spacing={[3, 4]}>
         {body && body.length ? body.map((text, key) => <Body key={key}>{text}</Body>) : body}


### PR DESCRIPTION
This PR enables an optional `title` prop for a `ScreenBody`. For advanced layouts, the title may sometimes need to be contained in a wrapper outside of `ScreenBody`.

[See corresponding PR in `blockstack-app`](https://github.com/blockstack/blockstack-app/pull/68)