### PR TITLE
Update screen components

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,5 +63,6 @@ module.exports = {
     'react/jsx-uses-vars': [2],
     'react/jsx-key': [0],
     'react/prop-types': [0],
+    'react/display-name': [0],
   },
 };

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@blockstack/ui": "^1.0.0-alpha.24",
+    "@blockstack/ui": "^1.0.0-alpha.27",
     "mdi-react": "^6.6.0",
     "styled-components": "^5.0.0",
     "use-events": "^1.4.1"

--- a/src/react/components/checklist/index.tsx
+++ b/src/react/components/checklist/index.tsx
@@ -15,15 +15,15 @@ interface CheckListProps {
 }
 
 const CheckList: React.FC<CheckListProps> = ({ items }) => (
-  <>
+  <Box>
     {items.map((item, key) => {
       const Icon = item.icon;
       const { text } = item;
       return (
         <Flex
           px={6}
-          pb={5}
-          pt={key === 0 ? 0 : 5}
+          pb={3}
+          pt={key === 0 ? 0 : 3}
           borderBottom={items.length - 1 !== key ? '1px solid' : 'unset'}
           borderColor="inherit"
           align="center"
@@ -37,7 +37,7 @@ const CheckList: React.FC<CheckListProps> = ({ items }) => (
         </Flex>
       );
     })}
-  </>
+  </Box>
 );
 
 export { CheckList };

--- a/src/react/components/screen/screen-actions.tsx
+++ b/src/react/components/screen/screen-actions.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-
 import { Flex } from '@blockstack/ui';
 
-export const ScreenActions: React.FC = ({ children }) => <Flex p={6}>{children}</Flex>;
+export const ScreenActions: React.FC = ({ children, ...rest }) => (
+  <Flex px={6} {...rest}>
+    {children}
+  </Flex>
+);

--- a/src/react/components/screen/screen-actions.tsx
+++ b/src/react/components/screen/screen-actions.tsx
@@ -1,8 +1,4 @@
 import React from 'react';
-import { Flex } from '@blockstack/ui';
+import { Flex, FlexProps } from '@blockstack/ui';
 
-export const ScreenActions: React.FC = ({ children, ...rest }) => (
-  <Flex px={6} {...rest}>
-    {children}
-  </Flex>
-);
+export const ScreenActions = (props: FlexProps) => <Flex px={6} {...props} />;

--- a/src/react/components/screen/screen-body.tsx
+++ b/src/react/components/screen/screen-body.tsx
@@ -11,7 +11,7 @@ export interface ScreenBodyProps extends BoxProps {
 }
 
 export const ScreenBody = ({ title, body, pretitle, fullWidth, ...rest }: ScreenBodyProps) => (
-  <Stack spacing={2} mx={fullWidth ? 0 : 6} {...rest}>
+  <Stack spacing={3} mx={fullWidth ? 0 : 6} {...rest}>
     {pretitle && <Pretitle>{pretitle}</Pretitle>}
     {title && <Title>{title}</Title>}
     {body && (

--- a/src/react/components/screen/screen-header.tsx
+++ b/src/react/components/screen/screen-header.tsx
@@ -7,12 +7,12 @@ import { AppIcon } from '../app-icon';
 
 interface HeaderTitleProps {
   title?: string | JSX.Element;
-  hideIcon?: boolean;
+  hideLogo?: boolean;
 }
 
-const HeaderTitle: React.FC<HeaderTitleProps> = ({ hideIcon, title }) => (
+const HeaderTitle: React.FC<HeaderTitleProps> = ({ hideLogo, title }) => (
   <Flex align="center">
-    {hideIcon ? null : <Logo mr={2} />}
+    {hideLogo ? null : <Logo mr={2} />}
     <Text fontWeight="bold" fontSize={'12px'}>
       {title}
     </Text>
@@ -27,9 +27,16 @@ export interface ScreenHeaderProps {
   title?: string | JSX.Element;
   close?: () => void;
   hideIcon?: boolean;
+  hideLogo?: boolean;
 }
 
-export const ScreenHeader = ({ appDetails, title = 'Data Vault', hideIcon = false, ...rest }: ScreenHeaderProps) => {
+export const ScreenHeader = ({
+  appDetails,
+  title = 'Data Vault',
+  hideIcon = false,
+  hideLogo = false,
+  ...rest
+}: ScreenHeaderProps) => {
   const { name, icon } = useAppDetails();
 
   let appName = name;
@@ -59,7 +66,7 @@ export const ScreenHeader = ({ appDetails, title = 'Data Vault', hideIcon = fals
             <ChevronRightIcon size={20} />
           </Box>
         ) : null}
-        <HeaderTitle hideIcon={hideIcon} title={title} />
+        <HeaderTitle hideLogo={hideLogo} title={title} />
       </Flex>
     </Flex>
   );

--- a/src/react/components/screen/screen.tsx
+++ b/src/react/components/screen/screen.tsx
@@ -1,25 +1,41 @@
 import React from 'react';
 
-import { Flex, BoxProps } from '@blockstack/ui';
+import { Stack, BoxProps, StackProps } from '@blockstack/ui';
 import { ScreenLoader } from './screen-loader';
 
-interface ScreenBodyProps extends BoxProps {
+interface ScreenBodyProps extends BoxProps, StackProps {
   noMinHeight?: boolean;
   isLoading?: boolean;
 }
 
-export const Screen: React.FC<ScreenBodyProps> = ({ noMinHeight, isLoading, children, ...rest }) => (
+export const Screen: React.FC<ScreenBodyProps> = ({
+  isInline,
+  spacing = 4,
+  align,
+  justify,
+  shouldWrapChildren,
+  noMinHeight,
+  isLoading,
+  children,
+  ...rest
+}) => (
   <>
     <ScreenLoader isLoading={isLoading} />
-    <Flex
+    <Stack
       width="100%"
       flexDirection="column"
       letterSpacing="tighter"
       minHeight={noMinHeight ? undefined : ['calc(100vh - 57px)', 'unset']}
       style={{ pointerEvents: isLoading ? 'none' : 'unset' }}
+      spacing={spacing}
+      isInline={isInline}
+      align={align}
+      justify={justify}
+      shouldWrapChildren={shouldWrapChildren}
+      pb={6}
       {...rest}
     >
       {children}
-    </Flex>
+    </Stack>
   </>
 );

--- a/src/react/components/screens/finished.tsx
+++ b/src/react/components/screens/finished.tsx
@@ -33,7 +33,7 @@ export const Finished = () => {
         title={`${name} has been connected to your Data Vault`}
         body={[`Everything you do in ${name} will be private, secure, and only accessible with your Secret Key.`]}
       />
-      <ScreenActions>
+      <ScreenActions pb={6}>
         <Button width="100%" onClick={() => doCloseDataVault()}>
           Close
         </Button>

--- a/src/react/components/screens/finished.tsx
+++ b/src/react/components/screens/finished.tsx
@@ -33,7 +33,7 @@ export const Finished = () => {
         title={`${name} has been connected to your Data Vault`}
         body={[`Everything you do in ${name} will be private, secure, and only accessible with your Secret Key.`]}
       />
-      <ScreenActions pb={6}>
+      <ScreenActions>
         <Button width="100%" onClick={() => doCloseDataVault()}>
           Close
         </Button>

--- a/src/react/components/screens/intro.tsx
+++ b/src/react/components/screens/intro.tsx
@@ -24,12 +24,12 @@ const AppElement = ({
     <Box position="absolute" top="-4px" right="-4px">
       <Logo />
     </Box>
-    <AppIcon size="64px" src={icon} alt={name} borderRadius="0" />
+    <AppIcon size="72px" src={icon} alt={name} borderRadius="0" />
   </Box>
 );
 
 export const Intro = () => {
-  const { doGoToHowItWorksScreen, doFinishAuth, doStartAuth, isAuthenticating, authOptions } = useConnect();
+  const { doGoToHowItWorksScreen, doFinishAuth, doStartAuth, authOptions } = useConnect();
   const { name, icon } = useAppDetails();
 
   return (
@@ -39,17 +39,20 @@ export const Intro = () => {
         fullWidth
         title={`Use ${name} privately and securely with Data Vault`}
         body={[
-          'Create your Data Vault to continue.',
-          <Box mx="auto" mb={2} width="100%" height="1px" bg="#E5E5EC" />,
+          <Box mx="auto" width="100%" height="1px" bg="#E5E5EC" />,
           <CheckList
             items={[
               {
+                icon: () => <AppIcon alt={name} src={icon} />,
+                text: `You will use your Data Vault to sign into ${name} privately`,
+              },
+              {
                 icon: EncryptionIcon,
-                text: `Keep everything you do in ${name} private with encryption and blockchain`,
+                text: `Data Vault keeps what you do in ${name} private using encryption and blockchain`,
               },
               {
                 icon: AppsIcon,
-                text: 'Data Vault is easy to set up and free to use with over 300 apps',
+                text: 'Data Vault is free to use with over 300 apps',
               },
             ]}
           />,
@@ -58,7 +61,6 @@ export const Intro = () => {
       <ScreenActions>
         <Button
           width="100%"
-          isLoading={isAuthenticating}
           onClick={() => {
             doStartAuth();
             // eslint-disable-next-line @typescript-eslint/no-floating-promises
@@ -75,7 +77,7 @@ export const Intro = () => {
         </Button>
       </ScreenActions>
       <ScreenFooter>
-        <Stack spacing={4} mb={6} isInline>
+        <Stack spacing={4} isInline>
           <Link
             onClick={() => {
               doStartAuth();

--- a/src/react/components/typography/index.tsx
+++ b/src/react/components/typography/index.tsx
@@ -2,9 +2,7 @@ import React from 'react';
 import { Text, Box, BoxProps } from '@blockstack/ui';
 import ChevronLeftIcon from 'mdi-react/ChevronLeftIcon';
 
-const Title: React.FC = props => (
-  <Text width="100%" fontWeight="medium" fontSize={['20px', '24px']} lineHeight={['28px', '32px']} {...props} />
-);
+const Title: React.FC = props => <Text width="100%" fontWeight="medium" fontSize="24px" lineHeight="32px" {...props} />;
 
 const Pretitle: React.FC = props => (
   <Text

--- a/yarn.lock
+++ b/yarn.lock
@@ -857,15 +857,15 @@
   resolved "https://registry.yarnpkg.com/@blockstack/prettier-config/-/prettier-config-0.0.5.tgz#871bd2a38b5bc9aabb1cefeeba6199cc64098957"
   integrity sha512-A+wfdVwD1Sxd/D3PPJI67Evo7q2fp15hCOFLB5jmzcS1MdN8BQdFm6j51Sti8xLN4qHmuYkicbFBUluGx2h63g==
 
-"@blockstack/ui@^1.0.0-alpha.24":
-  version "1.0.0-alpha.24"
-  resolved "https://registry.yarnpkg.com/@blockstack/ui/-/ui-1.0.0-alpha.24.tgz#e82bd2c9d96ab4d1c4989a8864c6b626d3491c8b"
-  integrity sha512-U2ESz5K5fxz+KNDM9VhcIM/bnOzGtukf6QQ8nduiXCjOAKe7ct6IFqMk1L7LapRSfg+mMJziVHdjLSj0unJoHw==
+"@blockstack/ui@^1.0.0-alpha.27":
+  version "1.0.0-alpha.27"
+  resolved "https://registry.yarnpkg.com/@blockstack/ui/-/ui-1.0.0-alpha.27.tgz#1471a085b3f68285c0a8d79cb9ee292a40141106"
+  integrity sha512-DCih4GkfEojd8FPY8538BzcGtETWrYpPln8Yv9XKAsFoEeIbgju4rdJufzUnwvbX3P4fApS/z9cIlZ+5meX4bg==
   dependencies:
     "@styled-system/css" "5.1.4"
     "@types/color" "^3.0.1"
     "@types/styled-components" "^4.4.2"
-    "@types/styled-system" "^5.1.4"
+    "@types/styled-system" "^5.1.5"
     "@types/styled-system__css" "^5.0.4"
     color "3.1.2"
     prop-types "^15.7.2"
@@ -1405,10 +1405,10 @@
     "@types/react-native" "*"
     csstype "^2.2.0"
 
-"@types/styled-system@^5.1.4":
-  version "5.1.4"
-  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.4.tgz#c273b1ebb9b26cb1bd9282c994fc56c82d0fbfaf"
-  integrity sha512-iBtFFmlxBbiTMpoKvRupwg75PeVbf7BBsgTlpcVBBbZyUKrhuU/4jtJQUn/wsSndKfxW0U9T17Geq0GGFWkCZw==
+"@types/styled-system@^5.1.5":
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/@types/styled-system/-/styled-system-5.1.5.tgz#91c46bdc72f09a4d13b215695687ce35382ccad8"
+  integrity sha512-jYTj774fMiRZ7YgmQK6WxiHSI+ket6WqHPQQEq7CURkVqOI6YWUHKqn0WcLwrqQ+fPHYQt9DdoJb7ydZBMmFwQ==
   dependencies:
     csstype "^2.6.4"
 


### PR DESCRIPTION
### What this does

#### Screen components
- This PR changes the way that `Screen` spaces out objects. We are now using `Stack` instead of `Flex` as the main wrapper component, with a spacing prop of `3` provided.

- `ScreenActions` has been updated to allow for props to be passed to the underlying `Flex` element, and some spacing adjustments have been made.

- `ScreenHeader` has been updated to allow us to hide only the logo, or only the appIcon if we choose to.

#### Intro Screen
- the loading state no longer affects the UI.
- Added and adjusted the checklist content describing the benefits of Data Vault


Connected to this [blockstack-app PR](https://github.com/blockstack/blockstack-app/pull/69).
