### PR TITLE
refactor: Attempted improvement of browser popup opening position

### DIFF
--- a/src/react/components/screens/intro.tsx
+++ b/src/react/components/screens/intro.tsx
@@ -29,7 +29,7 @@ const AppElement = ({
 );
 
 export const Intro = () => {
-  const { doGoToHowItWorksScreen, doFinishAuth, doStartAuth, isAuthenticating, authOptions } = useConnect();
+  const { doGoToHowItWorksScreen, doFinishAuth, doStartAuth, authOptions } = useConnect();
   const { name, icon } = useAppDetails();
 
   return (
@@ -58,7 +58,6 @@ export const Intro = () => {
       <ScreenActions>
         <Button
           width="100%"
-          isLoading={isAuthenticating}
           onClick={() => {
             doStartAuth();
             // eslint-disable-next-line @typescript-eslint/no-floating-promises


### PR DESCRIPTION
Closes #11

This PR aims to ensure the auth pop up covers the modal open within the viewport. 

It is not a fool-proof solution, there are some edge cases where it doesn't work perfectly. This complexity is owed to the fact the popup opens relative to the screen, not the browser viewport.

Below is a reasonably complex example. The window is centred in the screen, and a browser side panel is open, all of these need to be factored into the calculation of which coordinate the window should open on.

**Note**: if you try this out with dev tools open, _it will_ open in the wrong position. This is because of the `outerWidth - innerWidth` calculation. I figure regular users will more often have a left side panel open than a right one.

We might be able to cover some more edge cases using the [VisualViewport API](https://developer.mozilla.org/en-US/docs/Web/API/VisualViewport), but thing we're good without for time being.

**Tested on these MacOS browsers**
- Chrome 
- Firefox
- Safari
- Edge
- Opera

**Safari demo**

![safari-modal-open5](https://user-images.githubusercontent.com/1618764/73347309-aedda180-4287-11ea-8114-77849da2bea4.gif)
