### PR TITLE
fix: only use window for scroll lock if available

### DIFF
--- a/src/react/hooks/use-scroll-lock.tsx
+++ b/src/react/hooks/use-scroll-lock.tsx
@@ -10,14 +10,19 @@ declare global {
   }
 }
 
-// this is necessary because we may share instances of this file on a page so we store these globally
-window.__useScrollLockInstances = window.__useScrollLockInstances || new Set<{}>();
+let instances: Set<{}> = new Set();
+
+if (typeof window !== 'undefined') {
+  // this is necessary because we may share instances of this file on a page so we store these globally
+  window.__useScrollLockInstances = window.__useScrollLockInstances || new Set<{}>();
+  instances = window.__useScrollLockInstances;
+}
+
 const originalStyle = () => {
   window.__useScrollLockStyle = window.__useScrollLockStyle || window.getComputedStyle(document.body).overflow;
 
   return window.__useScrollLockStyle;
 };
-const instances: Set<{}> = window.__useScrollLockInstances;
 
 const registerInstance = (instance: {}) => {
   if (instances.size === 0) {


### PR DESCRIPTION
Banter broke because importing `connect` tries to use `window`. This changes the code to only use `window` if available.