### PR TITLE
feat: window.focus() after auth finished

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -106,6 +106,7 @@ const setupListener = ({ popup, authRequest, finished, authURL, userSession }: L
     const data: FinishedEventData = event.data;
     if (data.authRequest === authRequest) {
       if (finished) {
+        window.focus();
         const { authResponse } = data;
         await userSession.handlePendingSignIn(authResponse);
         finished({


### PR DESCRIPTION
The app has a (short) timeout, while it waits to see if it can use message passing to finish auth. This adds a `window.focus()` call, so that even if the app doesn't close, we can still grab focus right after auth.