### PR TITLE
refactor: change url for chrome ext install

### DIFF
--- a/.changeset/lazy-foxes-tap.md
+++ b/.changeset/lazy-foxes-tap.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect-ui': patch
+---
+
+This changes the path for downloading the chrome web wallet to be the chrome store

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -4,6 +4,9 @@ import type { AuthOptions } from '@stacks/connect/types/auth';
 import { getBrowser } from './extension-util';
 import { StacksIcon } from './assets/stacks-icon';
 
+const CHROME_STORE_URL =
+  'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj';
+
 @Component({
   tag: 'connect-modal',
   styleUrl: 'modal.scss',
@@ -59,7 +62,11 @@ export class Modal {
                   <button
                     class="button"
                     onClick={() => {
-                      window.open('https://www.hiro.so/wallet/install-web', '_blank');
+                      if (browser === 'Chrome') {
+                        window.open(CHROME_STORE_URL, '_blank');
+                      } else {
+                        window.open('https://www.hiro.so/wallet/install-web', '_blank');
+                      }
                       this.openedInstall = true;
                     }}
                   >


### PR DESCRIPTION
## Description

This PR changes the url path for installing the web wallet Chrome extension. Now that the wallet will be available for install in the app store, we no longer want to route users to the hiro.so path.

For details refer to issue #96

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information

Provide context on how tests should be performed.

1. Is testing required for this change?
TBD

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `yarn lerna run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
