### PR TITLE
feat: support onCancel

### DIFF
--- a/.changeset/stupid-humans-promise.md
+++ b/.changeset/stupid-humans-promise.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': minor
+---
+
+This adds calling an onCancel callback when the auth and transaction requests fail.

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -83,7 +83,8 @@ export const authenticate = (authOptions: AuthOptions) => {
       });
     })
     .catch(error => {
-      onCancel?.(error);
+      console.error('[Connect] Error during auth request', error);
+      onCancel?.();
     });
 };
 

--- a/packages/connect/src/transactions/index.ts
+++ b/packages/connect/src/transactions/index.ts
@@ -103,6 +103,7 @@ const openTransactionPopup = ({ token, options }: TransactionPopup) => {
       const { txRaw } = data;
       const txBuffer = Buffer.from(txRaw.replace(/^0x/, ''), 'hex');
       const stacksTransaction = deserializeTransaction(new BufferReader(txBuffer));
+
       if ('sponsored' in options && options.sponsored) {
         const finishedCallback = options.onFinish || options.finished;
         finishedCallback?.({
@@ -118,6 +119,7 @@ const openTransactionPopup = ({ token, options }: TransactionPopup) => {
     })
     .catch(error => {
       console.error('[Connect] Error during transaction request', error);
+      options.onCancel?.();
     });
 
   if (true) return;

--- a/packages/connect/src/types/auth.ts
+++ b/packages/connect/src/types/auth.ts
@@ -27,7 +27,7 @@ export interface AuthOptions {
    * */
   onFinish?: (payload: FinishedData) => void;
   /** This callback is fired if the user exits before finishing */
-  onCancel?: (error?: Error) => void;
+  onCancel?: () => void;
   /**
    * @deprecated Authentication is no longer supported through a hosted
    * version. Users must install an extension.

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -30,6 +30,7 @@ export interface TxBase {
 
 export interface SponsoredFinishedTxPayload {
   txRaw: string;
+  cancel: boolean;
 }
 
 export interface SponsoredFinishedTxData extends SponsoredFinishedTxPayload {
@@ -38,6 +39,7 @@ export interface SponsoredFinishedTxData extends SponsoredFinishedTxPayload {
 
 export interface FinishedTxPayload extends SponsoredFinishedTxPayload {
   txId: string;
+  cancel: boolean;
 }
 
 export interface FinishedTxData extends FinishedTxPayload {
@@ -80,12 +82,14 @@ export interface OptionsBase {
 
 export type SponsoredFinished = (data: SponsoredFinishedTxData) => void;
 export type Finished = (data: FinishedTxData) => void;
+export type Canceled = () => void;
 
 export interface SponsoredOptionsBase extends TxBase, OptionsBase {
   sponsored: true;
   /** @deprecated use `onFinish` */
   finished?: SponsoredFinished;
   onFinish?: SponsoredFinished;
+  onCancel?: Canceled;
 }
 
 export interface RegularOptionsBase extends TxBase, OptionsBase {
@@ -93,6 +97,7 @@ export interface RegularOptionsBase extends TxBase, OptionsBase {
   /** @deprecated use `onFinish` */
   finished?: Finished;
   onFinish?: Finished;
+  onCancel?: Canceled;
 }
 
 export type ContractCallRegularOptions = ContractCallBase & RegularOptionsBase;


### PR DESCRIPTION
## Description

This PR adds an `onCancel` callback function to a transaction. It also adds a boolean on the tx payload to check if the callback function should be run.

Ex. `onCancel` will be called when a user closes/cancels a transaction window.

`stacks-web-wallet`:
Issue: https://github.com/blockstack/stacks-wallet-web/issues/959
PR: https://github.com/blockstack/stacks-wallet-web/pull/1175

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information
TBD.

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `yarn lerna run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
