### PR TITLE
refactor: change url for firefox ext install

### DIFF
--- a/.changeset/chilly-guests-punch.md
+++ b/.changeset/chilly-guests-punch.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect-ui': patch
+---
+
+This changes the path for downloading the firefox web wallet to be the firefox store

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -6,6 +6,7 @@ import { StacksIcon } from './assets/stacks-icon';
 
 const CHROME_STORE_URL =
   'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj';
+const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/';
 
 @Component({
   tag: 'connect-modal',
@@ -64,6 +65,8 @@ export class Modal {
                     onClick={() => {
                       if (browser === 'Chrome') {
                         window.open(CHROME_STORE_URL, '_blank');
+                      } else if (browser === 'Firefox') {
+                        window.open(FIREFOX_STORE_URL, '_blank');
                       } else {
                         window.open('https://www.hiro.so/wallet/install-web', '_blank');
                       }


### PR DESCRIPTION
## Description

This PR changes the url path for installing the web wallet Firefox extension. Now that the wallet will be available for install in the add-ons store, we no longer want to route users to the hiro.so path.

For details refer to issue #97

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Checklist
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
