### PR TITLE
fix: handle closing the install prompt modal

### DIFF
--- a/.changeset/funny-mayflies-wait.md
+++ b/.changeset/funny-mayflies-wait.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect': patch
+'@stacks/connect-ui': patch
+---
+
+This fixes closing the modal that prompts users to install the stacks wallet.

--- a/packages/connect-ui/src/components.d.ts
+++ b/packages/connect-ui/src/components.d.ts
@@ -25,7 +25,6 @@ declare global {
 declare namespace LocalJSX {
     interface ConnectModal {
         "authOptions"?: AuthOptions;
-        "onHandleCloseModal"?: (event: CustomEvent<any>) => void;
     }
     interface IntrinsicElements {
         "connect-modal": ConnectModal;

--- a/packages/connect-ui/src/components/modal/modal.scss
+++ b/packages/connect-ui/src/components/modal/modal.scss
@@ -1,16 +1,19 @@
-:host { all: initial }
+:host {
+  all: initial;
+}
 
 .modal-container {
   display: flex;
   flex-direction: column;
-  background-color: rgba(0,0,0,0.48);
+  background-color: rgba(0, 0, 0, 0.48);
   width: 100%;
   height: 100%;
   position: fixed;
   top: 0px;
   left: 0px;
   justify-content: center;
-  font-family: "Inter",-apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
   z-index: 8999;
 }
 
@@ -75,7 +78,7 @@
   box-sizing: border-box;
   width: 100%;
   height: 1px;
-  background: #E5E5EC;
+  background: #e5e5ec;
 }
 
 .intro-entry {
@@ -151,7 +154,7 @@
 .modal-footer {
   margin-top: 10px;
   padding: 24px 0;
-  background-color: #F7F7FA;
+  background-color: #f7f7fa;
   text-align: center;
   border-radius: 0 0 6px 6px;
 
@@ -168,10 +171,10 @@
   display: inline;
   font-size: 12px;
   line-height: 1.333;
-  -webkit-letter-spacing: 0.00em;
-  -moz-letter-spacing: 0.00em;
-  -ms-letter-spacing: 0.00em;
-  letter-spacing: 0.00em;
+  -webkit-letter-spacing: 0em;
+  -moz-letter-spacing: 0em;
+  -ms-letter-spacing: 0em;
+  letter-spacing: 0em;
   white-space: unset;
   cursor: pointer;
   text-decoration: none;

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -1,4 +1,4 @@
-import { Component, h, Prop, Event, EventEmitter, State } from '@stencil/core';
+import { Component, h, Prop, State, Element } from '@stencil/core';
 import { CloseIcon } from './assets/close-icon';
 import type { AuthOptions } from '@stacks/connect/types/auth';
 import { getBrowser } from './extension-util';
@@ -16,29 +16,23 @@ const CHROME_STORE_URL =
 export class Modal {
   @Prop() authOptions: AuthOptions;
 
-  @Event()
-  handleCloseModal: EventEmitter;
-
   @State()
-  openedInstall: boolean;
+  hasOpenedInstall: boolean;
 
-  handleOpenedInstall() {
-    this.openedInstall = true;
+  @Element() modalEl: HTMLElement;
+
+  handleCloseModal() {
+    this.modalEl.remove();
   }
 
   render() {
     const browser = getBrowser();
-    const handleContainerClick = (event: MouseEvent) => {
-      const target = event.target as HTMLDivElement;
-      if (target.className?.includes && target.className.includes('modal-container')) {
-        this.handleCloseModal.emit();
-      }
-    };
+
     return (
-      <div class="modal-container" onClick={handleContainerClick}>
+      <div class="modal-container">
         <div class="modal-body">
           <div class="modal-top">
-            <CloseIcon onClick={() => this.handleCloseModal.emit()} />
+            <CloseIcon onClick={() => this.handleCloseModal()} />
           </div>
           <div class="modal-content">
             <div>
@@ -53,7 +47,7 @@ export class Modal {
                 {this.authOptions.appDetails.name}.
                 {browser ? ` Add it to ${browser} to continue.` : ''}
               </div>
-              {this.openedInstall ? (
+              {this.hasOpenedInstall ? (
                 <div class="intro-subtitle pxl">
                   After installing Stacks Wallet, reload this page and sign in.
                 </div>
@@ -67,7 +61,7 @@ export class Modal {
                       } else {
                         window.open('https://www.hiro.so/wallet/install-web', '_blank');
                       }
-                      this.openedInstall = true;
+                      this.hasOpenedInstall = true;
                     }}
                   >
                     <span>Install Stacks Wallet</span>

--- a/packages/connect-ui/src/components/modal/readme.md
+++ b/packages/connect-ui/src/components/modal/readme.md
@@ -12,13 +12,6 @@
 | `authOptions` | --        |             | `AuthOptions` | `undefined` |
 
 
-## Events
-
-| Event              | Description | Type               |
-| ------------------ | ----------- | ------------------ |
-| `handleCloseModal` |             | `CustomEvent<any>` |
-
-
 ----------------------------------------------
 
 *Built with [StencilJS](https://stenciljs.com/)*

--- a/packages/connect-ui/src/index.html
+++ b/packages/connect-ui/src/index.html
@@ -25,7 +25,7 @@
                 icon: 'https://testnet-demo.blockstack.org/assets/messenger-app-icon.png',
             },
         };
-        showBlockstackConnect(authOptions)
+        showBlockstackConnect(authOptions);
     </script>
     <style>
         html, body {

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -22,11 +22,11 @@
   "typings": "dist/types/index.d.ts",
   "unpkg": "dist/bundle.js",
   "dependencies": {
+    "@rollup/plugin-replace": "^2.4.1",
     "@stacks/auth": "^1.2.3",
     "@stacks/connect-ui": "^5.0.6",
     "@stacks/network": "^1.2.2",
     "@stacks/transactions": "^1.3.0",
-    "@rollup/plugin-replace": "^2.4.1",
     "bn.js": "^5.2.0",
     "buffer": "6.0.3",
     "jsontokens": "^3.0.0",

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -18,10 +18,6 @@ export const showConnect = (authOptions: AuthOptions) => {
       element.remove();
     }
   };
-  element.addEventListener('onCloseModal', () => {
-    document.removeEventListener('keydown', handleEsc);
-    element.remove();
-  });
   document.addEventListener('keydown', handleEsc);
 };
 


### PR DESCRIPTION
## Description

This PR fixes a bug in the modal prompting users to install the stacks wallet which was not allowing them to close the modal. Now, clicking on the `X` to close the modal is working.

For details refer to issue #123

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing information
- Use the test-app and do not have the web wallet installed
- Click to sign up
- The `X` button should now close the modal

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `yarn lerna run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @hstove or @kyranjamie or @aulneau for review
