### PR TITLE
feat: expose profile url in auth response

### DIFF
--- a/.changeset/shaggy-kids-unite.md
+++ b/.changeset/shaggy-kids-unite.md
@@ -2,4 +2,4 @@
 '@stacks/connect': major
 ---
 
-This exposes the profile_url and other properties in the auth response. It also removes the deprecated 'finished' prop from AuthOptions as a breaking change. We will now only support the use of 'onFinish'.
+This exposes the profile_url and other properties in the auth response. It also removes the deprecated 'finished' prop from AuthOptions and transaction options as a breaking change. We will now only support the use of 'onFinish'.

--- a/.changeset/shaggy-kids-unite.md
+++ b/.changeset/shaggy-kids-unite.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': major
+---
+
+This exposes the profile_url and other properties in the auth response. It also removes the deprecated 'finished' prop from AuthOptions as a breaking change. We will now only support the use of 'onFinish'.

--- a/packages/connect-react/src/react/components/connect/context.tsx
+++ b/packages/connect-react/src/react/components/connect/context.tsx
@@ -1,5 +1,5 @@
 import React, { useReducer, createContext } from 'react';
-import { AuthOptions, FinishedData } from '@stacks/connect';
+import { AuthOptions, FinishedAuthData } from '@stacks/connect';
 import { UserSession } from '@stacks/auth';
 
 enum States {
@@ -13,7 +13,7 @@ type Dispatch = (action: Action) => void;
 type State = {
   isOpen: boolean;
   isAuthenticating: boolean;
-  authData?: FinishedData;
+  authData?: FinishedAuthData;
   authOptions: AuthOptions;
   userSession?: UserSession;
 };
@@ -26,7 +26,7 @@ const initialState: State = {
   authOptions: {
     redirectTo: '',
     manifestPath: '',
-    finished: () => null,
+    onFinish: () => null,
     authOrigin: undefined,
     sendToSignIn: false,
     appDetails: {

--- a/packages/connect-react/src/react/hooks/use-connect.ts
+++ b/packages/connect-react/src/react/hooks/use-connect.ts
@@ -9,13 +9,13 @@ import {
   openContractDeploy,
   openSTXTransfer,
   showBlockstackConnect,
-  FinishedData,
   ContractCallRegularOptions,
   ContractCallSponsoredOptions,
   ContractDeployRegularOptions,
   ContractDeploySponsoredOptions,
   STXTransferRegularOptions,
   STXTransferSponsoredOptions,
+  FinishedAuthData,
 } from '@stacks/connect';
 import { ConnectContext, ConnectDispatchContext, States } from '../components/connect/context';
 
@@ -31,7 +31,7 @@ export const useConnect = () => {
   const { isOpen, isAuthenticating, authData, authOptions, userSession } = useContext(
     ConnectContext
   );
-  const finishedCallback = authOptions.onFinish || authOptions.finished;
+
   const dispatch = useConnectDispatch();
 
   const doUpdateAuthOptions = (payload: Partial<AuthOptions>) => {
@@ -48,9 +48,8 @@ export const useConnect = () => {
       const _options: AuthOptions = {
         ...authOptions,
         ...options,
-        finished: undefined,
-        onFinish: (payload: FinishedData) => {
-          finishedCallback?.(payload);
+        onFinish: (payload: FinishedAuthData) => {
+          authOptions.onFinish?.(payload);
         },
         sendToSignIn: true,
       };
@@ -64,13 +63,13 @@ export const useConnect = () => {
     }
     authOptions && doUpdateAuthOptions(authOptions);
   };
+
   const doAuth = (options: Partial<AuthOptions> = {}) => {
     void authenticate({
       ...authOptions,
       ...options,
-      finished: undefined,
-      onFinish: (payload: FinishedData) => {
-        finishedCallback?.(payload);
+      onFinish: (payload: FinishedAuthData) => {
+        authOptions.onFinish?.(payload);
       },
     });
   };

--- a/packages/connect/src/auth.ts
+++ b/packages/connect/src/auth.ts
@@ -72,23 +72,21 @@ export const authenticate = async (authOptions: AuthOptions) => {
     }
   );
 
-  await provider
-    .authenticationRequest(authRequest)
-    .then(async authResponse => {
-      await userSession.handlePendingSignIn(authResponse);
-      const token = decodeToken(authResponse);
-      const payload = token?.payload;
-      const authResponsePayload = (payload as unknown) as AuthResponsePayload;
-      onFinish?.({
-        authResponse,
-        authResponsePayload,
-        userSession,
-      });
-    })
-    .catch(error => {
-      console.error('[Connect] Error during auth request', error);
-      onCancel?.();
+  try {
+    const authResponse = await provider.authenticationRequest(authRequest);
+    await userSession.handlePendingSignIn(authResponse);
+    const token = decodeToken(authResponse);
+    const payload = token?.payload;
+    const authResponsePayload = (payload as unknown) as AuthResponsePayload;
+    onFinish?.({
+      authResponse,
+      authResponsePayload,
+      userSession,
     });
+  } catch (error) {
+    console.error('[Connect] Error during auth request', error);
+    onCancel?.();
+  }
 };
 
 export const getUserData = async (userSession?: UserSession) => {

--- a/packages/connect/src/types/auth.ts
+++ b/packages/connect/src/types/auth.ts
@@ -1,7 +1,26 @@
 import type { UserSession } from '@stacks/auth';
 
-export interface FinishedData {
+export interface AuthResponsePayload {
+  private_key: string;
+  username: string | null;
+  hubUrl: string;
+  associationToken: string;
+  blockstackAPIUrl: string | null;
+  core_token: string | null;
+  email: string | null;
+  exp: number;
+  iat: number;
+  iss: string;
+  jti: string;
+  version: string;
+  profile: any;
+  profile_url: string;
+  public_keys: string[];
+}
+
+export interface FinishedAuthData {
   authResponse: string;
+  authResponsePayload: AuthResponsePayload;
   userSession: UserSession;
 }
 
@@ -17,15 +36,14 @@ export interface AuthOptions {
   /** The URL you want the user to be redirected to after authentication. */
   redirectTo?: string;
   manifestPath?: string;
-  /** @deprecated use `onFinish` */
-  finished?: (payload: FinishedData) => void;
   /**
    * This callback is fired after authentication is finished.
-   * The callback is called with a single object argument, with two keys:
-   * `userSession`: a UserSession object with `userData` included
+   * The callback is called with a single object argument, with three keys:
    * `authResponse`: the raw `authResponse` string that is returned from authentication
+   * `authResponsePayload`: an AuthResponsePayload object
+   * `userSession`: a UserSession object with `userData` included
    * */
-  onFinish?: (payload: FinishedData) => void;
+  onFinish?: (payload: FinishedAuthData) => void;
   /** This callback is fired if the user exits before finishing */
   onCancel?: () => void;
   /**

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -84,16 +84,12 @@ export type Canceled = () => void;
 
 export interface SponsoredOptionsBase extends TxBase, OptionsBase {
   sponsored: true;
-  /** @deprecated use `onFinish` */
-  finished?: SponsoredFinished;
   onFinish?: SponsoredFinished;
   onCancel?: Canceled;
 }
 
 export interface RegularOptionsBase extends TxBase, OptionsBase {
   sponsored?: false;
-  /** @deprecated use `onFinish` */
-  finished?: Finished;
   onFinish?: Finished;
   onCancel?: Canceled;
 }


### PR DESCRIPTION
## Description

This PR exposes the `profile_url` and other properties in the auth response.

For details refer to issue #127

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
Yes.

## Are documentation updates required?
TBD.

## Testing information
TBD.