### PR TITLE
fix: moved tsdx from dependencies to devDependencies

### DIFF
--- a/.changeset/ninety-teachers-hunt.md
+++ b/.changeset/ninety-teachers-hunt.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': minor
+---
+
+updated dependencies

--- a/.changeset/ninety-teachers-hunt.md
+++ b/.changeset/ninety-teachers-hunt.md
@@ -2,4 +2,4 @@
 '@stacks/connect': minor
 ---
 
-updated dependencies
+This update moves `tsdx` and other dependencies to the correct category of `devDependencies`, fixing a downstream issue in the todos example app.

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
+    "tsdx": "^0.14.1",
     "typescript": "4.2.3",
     "yalc": "^1.0.0-pre.50"
   },
@@ -65,8 +66,7 @@
     "is-regex": "^1.1.2",
     "jsx-ast-utils": "^3.2.0",
     "patch-package": "^6.4.7",
-    "postinstall-postinstall": "^2.1.0",
-    "tsdx": "^0.14.1"
+    "postinstall-postinstall": "^2.1.0"
   },
   "resolutions": {
     "tsdx": "^0.14.1"

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "packages/*"
   ],
   "devDependencies": {
+    "@babel/core": "^7.13.10",
+    "@babel/preset-env": "^7.13.10",
     "@changesets/changelog-github": "^0.3.0",
     "@changesets/cli": "^2.14.1",
     "@commitlint/cli": "^12.0.1",
@@ -51,6 +53,8 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "husky": "^5.1.3",
     "lerna": "^3.22.1",
+    "patch-package": "^6.4.7",
+    "postinstall-postinstall": "^2.1.0",
     "prettier": "^2.2.1",
     "react": "^17.0.1",
     "react-dom": "^17.0.1",
@@ -59,14 +63,10 @@
     "yalc": "^1.0.0-pre.50"
   },
   "dependencies": {
-    "@babel/core": "^7.13.10",
-    "@babel/preset-env": "^7.13.10",
     "bn.js": "^5.2.0",
     "buffer": "^6.0.3",
     "is-regex": "^1.1.2",
-    "jsx-ast-utils": "^3.2.0",
-    "patch-package": "^6.4.7",
-    "postinstall-postinstall": "^2.1.0"
+    "jsx-ast-utils": "^3.2.0"
   },
   "resolutions": {
     "tsdx": "^0.14.1"

--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -32,7 +32,6 @@
     "jsontokens": "^3.0.0",
     "readable-stream": "^3.6.0",
     "rollup": "^2.41.4",
-    "tsdx": "^0.14.1",
     "url": "^0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Description

This PR moves the `tsdx` package from `dependencies` to `devDependencies`.  This should resolve an error with the Todos App dev tutorial where a downstream dependency was failing a yarn preflight check.

For more details, see https://github.com/blockstack/docs/issues/1170.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No

## Are documentation updates required?
No

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [x] `yarn lerna run test` passes
- [x] Changelog is updated
- [x] Tag 1 of @hstove or @kyranjamie or @aulneau for review
