### PR TITLE
fix: remove cancel boolean from tx response

### DIFF
--- a/.changeset/honest-rockets-sneeze.md
+++ b/.changeset/honest-rockets-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect': patch
+---
+
+This removes the cancel boolean added to the tx response because it is not needed.

--- a/packages/connect/src/types/transactions.ts
+++ b/packages/connect/src/types/transactions.ts
@@ -30,7 +30,6 @@ export interface TxBase {
 
 export interface SponsoredFinishedTxPayload {
   txRaw: string;
-  cancel: boolean;
 }
 
 export interface SponsoredFinishedTxData extends SponsoredFinishedTxPayload {
@@ -39,7 +38,6 @@ export interface SponsoredFinishedTxData extends SponsoredFinishedTxPayload {
 
 export interface FinishedTxPayload extends SponsoredFinishedTxPayload {
   txId: string;
-  cancel: boolean;
 }
 
 export interface FinishedTxData extends FinishedTxPayload {


### PR DESCRIPTION
## Description

This PR simply removes the `cancel` boolean added to the tx response bc it isn't needed and was causing issues.
