### PR TITLE
fix: stencil custom elements

### DIFF
--- a/.changeset/silent-hotels-hunt.md
+++ b/.changeset/silent-hotels-hunt.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect-ui': patch
+---
+
+This changes to use a cdn to import defineCustomElements from stenciljs so it doesn't have to imported outside of connect-ui.

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -9,7 +9,7 @@
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/connect-ui/connect-ui.js",
   "files": [
-    "dist/"
+    "dist"
   ],
   "scripts": {
     "build": "stencil build --docs",
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stencil/core": "^2.4.0",
+    "@stencil/core": "^2.6.0",
     "@stencil/sass": "^1.4.1"
   },
   "license": "MIT",

--- a/packages/connect-ui/src/index.html
+++ b/packages/connect-ui/src/index.html
@@ -8,7 +8,9 @@
     <script type="module" src="/build/connect-ui.esm.js"></script>
     <script nomodule src="/build/connect-ui.js"></script>
     <script type="module">
-        import {showBlockstackConnect} from '/build/index.esm.js'
+        import { showBlockstackConnect } from '/build/index.esm.js'
+        import { defineCustomElements } from 'https://cdn.jsdelivr.net/npm/@ionic/core/loader/index.es2017.mjs';
+        defineCustomElements();
 
         const authOptions = {
             redirectTo: '/',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,10 +2531,10 @@
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
 
-"@stencil/core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.4.0.tgz#17b45629c8986e35dcbce3f7dab7d64beede83f2"
-  integrity sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==
+"@stencil/core@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.6.0.tgz#29da96d8b6fc83e689b9f297ef3e8b59b90a676a"
+  integrity sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==
 
 "@stencil/sass@^1.4.1":
   version "1.4.1"


### PR DESCRIPTION
This PR fixes a bug with importing `defineCustomElements()` in the connect package from `@stacks/connect-ui/dist/custom-elements` which causes failing tests. Instead, we import through the cdn in connect-ui so it is available to connect that way.