### PR TITLE
fix: define custom elements

### DIFF
--- a/.changeset/smooth-apples-count.md
+++ b/.changeset/smooth-apples-count.md
@@ -1,0 +1,6 @@
+---
+'@stacks/connect': patch
+'@stacks/connect-ui': patch
+---
+
+This makes modifications to our stencil config so we can import our custom elements properly in connect.

--- a/packages/connect-ui/package.json
+++ b/packages/connect-ui/package.json
@@ -1,15 +1,15 @@
 {
   "name": "@stacks/connect-ui",
   "version": "5.1.2",
-  "description": "Stencil Component Starter",
   "main": "dist/index.cjs.js",
   "module": "dist/index.js",
-  "types": "dist/custom-elements/index.d.ts",
+  "types": "dist/types/components.d.ts",
   "collection": "dist/collection/collection-manifest.json",
   "collection:main": "dist/collection/index.js",
   "unpkg": "dist/connect-ui/connect-ui.js",
   "files": [
-    "dist/"
+    "dist/",
+    "loader/"
   ],
   "scripts": {
     "build": "stencil build --docs",
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
-    "@stencil/core": "^2.4.0",
+    "@stencil/core": "^2.6.0",
     "@stencil/sass": "^1.4.1"
   },
   "license": "MIT",

--- a/packages/connect-ui/src/index.html
+++ b/packages/connect-ui/src/index.html
@@ -1,41 +1,10 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
-<head>
-    <meta charset="utf-8"/>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0"/>
-    <title>Stencil Component Starter</title>
-
-    <script type="module" src="/build/connect-ui.esm.js"></script>
-    <script nomodule src="/build/connect-ui.js"></script>
-    <script type="module">
-        import {showBlockstackConnect} from '/build/index.esm.js'
-
-        const authOptions = {
-            redirectTo: '/',
-            finished: ({userSession}) => {
-                const userData = userSession.loadUserData();
-                console.log(userData);
-            },
-            onCancel: () => {
-                console.log('popup closed!');
-            },
-            authOrigin: 'http://localhost:8080',
-            appDetails: {
-                name: 'Stencil App',
-                icon: 'https://testnet-demo.blockstack.org/assets/messenger-app-icon.png',
-            },
-        };
-        showBlockstackConnect(authOptions);
-    </script>
-    <style>
-        html, body {
-            margin: 0px;
-        }
-    </style>
-</head>
-<body>
-<h1>App Content</h1>
-<span>asdf</span>
-<div style="height: 1240px; width: 100px; background-color: blue;"></div>
-</body>
+    <head>
+        <meta charset="utf-8"/>
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Connect UI</title>
+        <script type="module" src="/build/connect-ui.esm.js"></script>
+        <script nomodule src="/build/connect-ui.js"></script>
+    </head>
 </html>

--- a/packages/connect-ui/stencil.config.ts
+++ b/packages/connect-ui/stencil.config.ts
@@ -8,9 +8,7 @@ export const config: Config = {
   outputTargets: [
     {
       type: 'dist',
-    },
-    {
-      type: 'dist-custom-elements-bundle',
+      esmLoaderPath: '../loader',
     },
     {
       type: 'docs-readme',

--- a/packages/connect/src/ui.ts
+++ b/packages/connect/src/ui.ts
@@ -1,6 +1,6 @@
 import { authenticate } from './auth';
 import type { AuthOptions } from './types/auth';
-import { defineCustomElements } from '@stacks/connect-ui';
+import { defineCustomElements } from '@stacks/connect-ui/loader';
 import { getStacksProvider } from './utils';
 
 export const showConnect = (authOptions: AuthOptions) => {
@@ -8,17 +8,19 @@ export const showConnect = (authOptions: AuthOptions) => {
     void authenticate(authOptions);
     return;
   }
-  defineCustomElements();
-  const element = document.createElement('connect-modal');
-  element.authOptions = authOptions;
-  document.body.appendChild(element);
-  const handleEsc = (ev: KeyboardEvent) => {
-    if (ev.key === 'Escape') {
-      document.removeEventListener('keydown', handleEsc);
-      element.remove();
-    }
-  };
-  document.addEventListener('keydown', handleEsc);
+  if (typeof window !== undefined) {
+    void defineCustomElements(window);
+    const element = document.createElement('connect-modal');
+    element.authOptions = authOptions;
+    document.body.appendChild(element);
+    const handleEsc = (ev: KeyboardEvent) => {
+      if (ev.key === 'Escape') {
+        document.removeEventListener('keydown', handleEsc);
+        element.remove();
+      }
+    };
+    document.addEventListener('keydown', handleEsc);
+  }
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2531,10 +2531,10 @@
     sha.js "^2.4.11"
     smart-buffer "^4.1.0"
 
-"@stencil/core@^2.4.0":
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.4.0.tgz#17b45629c8986e35dcbce3f7dab7d64beede83f2"
-  integrity sha512-gU6+Yyd6O0KrCSS/O6j8KKqmRo+/Dcs2fI0+APCpbAWK+nqhwDISpdnSEfGDCLMoAC08XOZCycBRk2K1VGnEcg==
+"@stencil/core@^2.6.0":
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/@stencil/core/-/core-2.6.0.tgz#29da96d8b6fc83e689b9f297ef3e8b59b90a676a"
+  integrity sha512-QsxWayZyusnqSZrlCl81R71rA3KqFjVVQSH4E0rGN15F1GdQaFonKlHLyCOLKLig1zzC+DQkLLiUuocexuvdeQ==
 
 "@stencil/sass@^1.4.1":
   version "1.4.1"


### PR DESCRIPTION
## Description

This PR updates our stenciljs config so that we have access to import `defineCustomElements` via the loader.

For details refer to issue #138 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] API reference/documentation update
- [ ] Other

## Does this introduce a breaking change?
No.

## Are documentation updates required?
No.

## Testing
- Test with the test-app in web wallet
- Make sure the wallet is uninstalled
- Click on `Sign up`
- Make sure the install modal launches w/out an error!
