### PR TITLE
fix: unsupported browsers

### DIFF
--- a/.changeset/green-masks-kneel.md
+++ b/.changeset/green-masks-kneel.md
@@ -1,0 +1,5 @@
+---
+'@stacks/connect-ui': patch
+---
+
+This adds handling unsupported browsers in the intro modal.

--- a/packages/connect-ui/src/components/modal/modal.scss
+++ b/packages/connect-ui/src/components/modal/modal.scss
@@ -41,10 +41,6 @@
 .header-left {
   display: flex;
   align-items: center;
-
-  span {
-    padding-left: 8px;
-  }
 }
 
 .header-right {
@@ -76,12 +72,20 @@
   color: #242629;
   font-family: 'Open Sauce One', -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial,
     sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol';
-  font-size: 32px;
   font-weight: 500;
-  line-height: 40px;
   padding: 24px 64px 10px 64px;
   display: block;
   text-align: center;
+}
+
+.supported {
+  font-size: 32px;
+  line-height: 40px;
+}
+
+.unsupported {
+  font-size: 24px;
+  line-height: 36px;
 }
 
 .modal-subtitle {
@@ -91,6 +95,11 @@
   color: #74777d;
   text-align: center;
   padding: 10px 32px 24px 32px;
+
+  a {
+    color: #74777d;
+    font-weight: 500;
+  }
 }
 
 .button-container {

--- a/packages/connect-ui/src/components/modal/modal.tsx
+++ b/packages/connect-ui/src/components/modal/modal.tsx
@@ -3,10 +3,13 @@ import CloseIcon from './assets/close-icon.svg';
 import KeyAndKeyhole from './assets/key-and-keyhole.svg';
 import StacksIcon from './assets/stacks-icon.svg';
 import type { AuthOptions } from '@stacks/connect/types/auth';
-import { getBrowser } from './extension-util';
+import { getBrowser } from './utils';
 
+const CHROME_BROWSER_URL = 'https://www.google.com/chrome/';
+const BRAVE_BROWSER_URL = 'https://brave.com/';
+const FIREFOX_BROWSER_URL = 'https://www.mozilla.org/en-US/';
 const CHROME_STORE_URL =
-  'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj';
+  'https://chrome.google.com/webstore/detail/stacks-wallet/ldinpeekobnhjjdofggfgjlcehhmanlj/';
 const FIREFOX_STORE_URL = 'https://addons.mozilla.org/en-US/firefox/addon/stacks-wallet/';
 
 @Component({
@@ -47,7 +50,6 @@ export class Modal {
           <div class="modal-header">
             <div class="header-left">
               <img src={StacksIcon} />
-              <span>Stacks Wallet</span>
             </div>
             <img class="header-right" src={CloseIcon} onClick={() => this.handleCloseModal()} />
           </div>
@@ -58,16 +60,41 @@ export class Modal {
                 <img src={this.authOptions.appDetails.icon} />
               </div>
             </div>
-            <span class="modal-title">{`Add Stacks Wallet to ${browser}`}</span>
+            {browser ? (
+              <span class="modal-title supported">Add Stacks Wallet to {browser}</span>
+            ) : (
+              <span class="modal-title unsupported">Your browser isn't supported</span>
+            )}
             <div class="modal-subtitle">
-              Stacks Wallet is your gateway to Stacks apps like {this.authOptions.appDetails.name}.
-              Add it to {browser} to continue.
+              {browser ? (
+                <div>
+                  Stacks Wallet is your gateway to Stacks apps like{' '}
+                  {this.authOptions.appDetails.name}. Add it to {browser} to continue.
+                </div>
+              ) : (
+                <div>
+                  To sign in to {this.authOptions.appDetails.name} using the Stacks Wallet browser
+                  extension, try{` `}
+                  <a href={CHROME_BROWSER_URL} target="_blank">
+                    Chrome
+                  </a>
+                  {`, `}
+                  <a href={BRAVE_BROWSER_URL} target="_blank">
+                    Brave
+                  </a>
+                  {`, or `}
+                  <a href={FIREFOX_BROWSER_URL} target="_blank">
+                    Firefox
+                  </a>
+                  {` on desktop.`}
+                </div>
+              )}
             </div>
             {this.hasOpenedInstall ? (
               <div class="modal-subtitle">
                 After installing Stacks Wallet, reload this page and sign in.
               </div>
-            ) : (
+            ) : browser ? (
               <div class="button-container">
                 <button
                   class="button"
@@ -78,7 +105,7 @@ export class Modal {
                   Download Stacks Wallet
                 </button>
               </div>
-            )}
+            ) : null}
             <div class="modal-footer">
               <span
                 class="link"

--- a/packages/connect-ui/src/components/modal/utils.ts
+++ b/packages/connect-ui/src/components/modal/utils.ts
@@ -31,15 +31,3 @@ export const getBrowser = (): Browser | null => {
   }
   return null;
 };
-
-export const onClick = () => {
-  const browser = getBrowser();
-  if (browser === 'Firefox') {
-    window.open('https://addons.mozilla.org/en-US/firefox/addon/blockstack/', '_blank');
-  } else if (browser === 'Chrome') {
-    window.open(
-      'https://chrome.google.com/webstore/detail/blockstack/mdhmgoflnkccjhcfbojdagggmklgfloo',
-      '_blank'
-    );
-  }
-};


### PR DESCRIPTION
This PR fixes a few minor ui related issues that I missed implementing the new intro modal design. In addition, I am just adding the unsupported browser text now bc I needed something to use. We can swap out the drawing once we have a new one?

For details refer to issue #143

Adds text for unsupported browser ...will still need to swap out drawing.
Issue: https://github.com/blockstack/connect/issues/95
![image](https://user-images.githubusercontent.com/6493321/121717311-a665bf80-caa6-11eb-8757-11e588c62b96.png)

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] API reference/documentation update
- [x] Other